### PR TITLE
feat: facilitar ejecucion de la demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# autobot
+# Autobot
+
+Sistema modular para simular clientes con personalidades complejas y evaluar el
+comportamiento de agentes de atención en la industria de la construcción.
+
+## Estructura principal
+
+- `src/autobot/models.py`: Modelos basados en dataclasses para escenarios, mensajes y
+  resultados de evaluación.
+- `src/autobot/personalities.py`: Perfiles psicológicos detallados.
+- `src/autobot/scenarios.py`: Biblioteca de escenarios realistas.
+- `src/autobot/context.py`: Gestor de contexto multi-turno con almacenamiento en
+  memoria.
+- `src/autobot/evaluation.py`: Motor de evaluación con rúbrica configurable.
+- `src/autobot/commands.py`: Sistema de comandos para iniciar y finalizar
+  simulaciones.
+
+## Instalación y pruebas
+
+```bash
+python -m venv .venv
+# En Linux/macOS
+source .venv/bin/activate
+# En Windows (PowerShell)
+.\.venv\Scripts\Activate.ps1
+pip install -e .
+black src tests
+pytest
+```
+
+## Ejecución de la demo
+
+Tras instalar las dependencias puedes ejecutar una simulación básica sin
+configuración adicional con:
+
+```bash
+# Linux/macOS/Windows
+python -m autobot.demo
+
+# Alternativa: ejecutar la demo directamente como módulo del paquete
+python -m autobot
+```
+
+El comando imprime en consola la información del escenario seleccionado, la
+conversación de ejemplo y el informe final generado por el motor de evaluación.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autobot"
+version = "0.1.0"
+description = "Sistema de simulación y evaluación para agentes de atención al cliente"
+authors = [{name = "Autobot Team"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.black]
+line-length = 88
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/autobot/__init__.py
+++ b/src/autobot/__init__.py
@@ -1,0 +1,13 @@
+"""Módulo principal del sistema Autobot."""
+
+from . import commands, context, demo, evaluation, models, personalities, scenarios
+
+__all__ = [
+    "commands",
+    "context",
+    "demo",
+    "evaluation",
+    "models",
+    "personalities",
+    "scenarios",
+]

--- a/src/autobot/__main__.py
+++ b/src/autobot/__main__.py
@@ -1,0 +1,15 @@
+"""Punto de entrada del paquete para ejecutar la demo integrada."""
+
+from __future__ import annotations
+
+from .demo import ejecutar_demo
+
+
+def main() -> None:
+    """Imprime en consola el resultado de la demo."""
+
+    print(ejecutar_demo())
+
+
+if __name__ == "__main__":  # pragma: no cover - compatibilidad con `python -m`
+    main()

--- a/src/autobot/commands.py
+++ b/src/autobot/commands.py
@@ -1,0 +1,104 @@
+"""Sistema de comandos para controlar simulaciones y evaluaciones."""
+
+from __future__ import annotations
+
+import random
+from datetime import UTC, datetime
+
+from .context import GestorContexto
+from .evaluation import AnalizadorConversacion, RubricaEvaluacion
+from .models import (
+    CanalComunicacion,
+    ConfiguracionSimulacion,
+    ContextoConversacion,
+    PersonalidadCliente,
+)
+from .personalities import PERFILES_PERSONALIDAD
+from .scenarios import ESCENARIOS_OBRA
+
+
+class SistemaComandos:
+    """Procesa comandos administrativos recibidos durante la simulación."""
+
+    def __init__(
+        self, gestor_contexto: GestorContexto, analizador: AnalizadorConversacion
+    ) -> None:
+        self._gestor_contexto = gestor_contexto
+        self._analizador = analizador
+
+    async def procesar(self, comando: str, sesion_id: str) -> str:
+        """Despacha la ejecución del comando solicitado."""
+
+        comando_normalizado = comando.strip().lower()
+        if comando_normalizado == "comenzar test":
+            return self._iniciar_simulacion(sesion_id)
+        if comando_normalizado == "/finalizar":
+            return await self._finalizar_simulacion(sesion_id)
+        raise ValueError(f"Comando no reconocido: {comando}")
+
+    def _iniciar_simulacion(self, sesion_id: str) -> str:
+        personalidad = random.choice(list(PersonalidadCliente))
+        canal = random.choice(list(CanalComunicacion))
+        escenario = random.choice(ESCENARIOS_OBRA)
+
+        configuracion = ConfiguracionSimulacion(
+            personalidad=personalidad,
+            canal=canal,
+            escenario=escenario,
+            timestamp_inicio=datetime.now(UTC),
+        )
+        contexto = ContextoConversacion(
+            sesion_id=sesion_id,
+            configuracion=configuracion,
+            estado_actual="iniciando",
+        )
+        self._gestor_contexto.inicializar_contexto(contexto)
+
+        perfil = PERFILES_PERSONALIDAD.get(personalidad)
+        mensaje_inicial = (
+            "Inicia la conversación con tu cliente."
+            if perfil is None
+            else (
+                f"Cliente {personalidad.value} listo para interactuar en {canal.value}."
+            )
+        )
+        return (
+            "✅ TEST INICIADO\n\n"
+            f"🎭 Personalidad: {personalidad.value}\n"
+            f"📱 Canal: {canal.value}\n"
+            f"📋 Escenario: {escenario.titulo}\n\n"
+            f"{mensaje_inicial}"
+        )
+
+    async def _finalizar_simulacion(self, sesion_id: str) -> str:
+        contexto = self._gestor_contexto.obtener_contexto(sesion_id)
+        resultado = await self._analizador.evaluar_conversacion(contexto)
+        return self._formatear_informe(resultado)
+
+    @staticmethod
+    def _formatear_informe(resultado) -> str:
+        encabezado = f"# Evaluación de la sesión {resultado.sesion_id}\n"
+        puntaje = f"Puntaje global: {resultado.puntaje_global:.1f}/100\n"
+        fortalezas = (
+            "\n".join(f"- {texto}" for texto in resultado.fortalezas)
+            or "- Sin fortalezas"
+        )
+        oportunidades = (
+            "\n".join(f"- {texto}" for texto in resultado.oportunidades_mejora)
+            or "- Sin oportunidades"
+        )
+        return (
+            f"{encabezado}\n{puntaje}\n"
+            "## Fortalezas\n"
+            f"{fortalezas}\n\n"
+            "## Oportunidades\n"
+            f"{oportunidades}\n\n"
+            f"## Resumen\n{resultado.resumen_ejecutivo}"
+        )
+
+
+def construir_sistema_comandos(gestor: GestorContexto, llm_client) -> SistemaComandos:
+    """Facilita la creación del sistema de comandos con dependencias configuradas."""
+
+    analizador = AnalizadorConversacion(llm_client, RubricaEvaluacion())
+    return SistemaComandos(gestor, analizador)

--- a/src/autobot/context.py
+++ b/src/autobot/context.py
@@ -1,0 +1,144 @@
+"""Gestión de contexto y utilidades auxiliares para la simulación."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict
+from datetime import UTC, datetime
+from enum import Enum
+from typing import Dict, Iterable, List, Optional
+
+from .models import ContextoConversacion, MensajeConversacion
+
+
+class GestorContexto:
+    """Mantiene el estado de la conversación con soporte de almacenamiento externo."""
+
+    def __init__(self, almacenamiento, ventana_contexto: int = 10) -> None:
+        self._almacenamiento = almacenamiento
+        self._ventana_contexto = ventana_contexto
+
+    def agregar_mensaje(self, sesion_id: str, mensaje: MensajeConversacion) -> None:
+        """Agrega un mensaje al historial y actualiza los datos persistidos."""
+
+        contexto = self.obtener_contexto(sesion_id)
+        contexto.historial.append(mensaje)
+
+        if mensaje.rol == "cliente":
+            self._extraer_datos_clave(contexto, mensaje.contenido)
+
+        self._guardar_contexto(sesion_id, contexto)
+
+    def obtener_contexto(self, sesion_id: str) -> ContextoConversacion:
+        """Recupera el contexto desde el almacenamiento o crea uno vacío."""
+
+        datos = self._almacenamiento.get(self._clave(sesion_id))
+        if datos is None:
+            raise KeyError(f"No existe contexto para la sesión {sesion_id!r}")
+
+        if isinstance(datos, bytes):
+            datos = datos.decode("utf-8")
+        payload = json.loads(datos)
+        return _contexto_desde_dict(payload)
+
+    def obtener_contexto_para_llm(self, sesion_id: str) -> str:
+        """Construye una representación textual de los últimos turnos."""
+
+        contexto = self.obtener_contexto(sesion_id)
+        mensajes_recientes = contexto.historial[-self._ventana_contexto :]
+        lineas: List[str] = ["# HISTORIAL DE CONVERSACIÓN:"]
+        for mensaje in mensajes_recientes:
+            rol = "TÚ (Cliente)" if mensaje.rol == "cliente" else "AGENTE"
+            lineas.append(f"[Turno {mensaje.turno}] {rol}:\n{mensaje.contenido}\n")
+        return "\n".join(lineas)
+
+    def inicializar_contexto(self, contexto: ContextoConversacion) -> None:
+        """Persiste un contexto recién creado."""
+
+        self._guardar_contexto(contexto.sesion_id, contexto)
+
+    def _guardar_contexto(self, sesion_id: str, contexto: ContextoConversacion) -> None:
+        payload = json.dumps(asdict(contexto), default=_serializar_valor)
+        self._almacenamiento.setex(self._clave(sesion_id), 86400, payload)
+
+    @staticmethod
+    def _extraer_datos_clave(contexto: ContextoConversacion, texto: str) -> None:
+        """Extrae identificadores relevantes a partir de la conversación."""
+
+        if re.findall(r"#[\w-]+", texto):
+            contexto.datos_clave_mencionados["numero_pedido"] = True
+
+        if any(palabra in texto.lower() for palabra in ("hace", "días", "semanas")):
+            contexto.datos_clave_mencionados["fecha_problema"] = True
+
+    @staticmethod
+    def _clave(sesion_id: str) -> str:
+        return f"contexto:{sesion_id}"
+
+
+class AlmacenamientoEnMemoria:
+    """Implementación simple que emula las operaciones esenciales de Redis."""
+
+    def __init__(self) -> None:
+        self._datos: Dict[str, Dict[str, str]] = {}
+
+    def get(self, clave: str) -> Optional[str]:
+        elemento = self._datos.get(clave)
+        if elemento is None:
+            return None
+        return elemento["valor"]
+
+    def setex(self, clave: str, _ttl: int, valor: str) -> None:  # noqa: D401
+        self._datos[clave] = {
+            "valor": valor,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+
+    def items(self) -> Iterable:
+        return self._datos.items()
+
+
+def _serializar_valor(valor):  # noqa: D401
+    if isinstance(valor, datetime):
+        return valor.isoformat()
+    if isinstance(valor, Enum):
+        return valor.value
+    raise TypeError(f"Tipo no serializable: {type(valor)!r}")
+
+
+def _contexto_desde_dict(payload: Dict) -> ContextoConversacion:
+    configuracion = payload["configuracion"]
+    escenario = configuracion["escenario"]
+    from .models import (
+        CanalComunicacion,
+        ConfiguracionSimulacion,
+        EscenarioObra,
+        PersonalidadCliente,
+    )
+
+    contexto = ContextoConversacion(
+        sesion_id=payload["sesion_id"],
+        configuracion=ConfiguracionSimulacion(
+            personalidad=PersonalidadCliente(configuracion["personalidad"]),
+            canal=CanalComunicacion(configuracion["canal"]),
+            escenario=EscenarioObra(**escenario),
+            duracion_maxima=configuracion.get("duracion_maxima", 20),
+            nivel_dificultad=configuracion.get("nivel_dificultad", 0.7),
+            timestamp_inicio=datetime.fromisoformat(configuracion["timestamp_inicio"]),
+        ),
+        historial=[
+            MensajeConversacion(
+                turno=entrada["turno"],
+                rol=entrada["rol"],
+                contenido=entrada["contenido"],
+                timestamp=datetime.fromisoformat(entrada["timestamp"]),
+                metadatos=entrada.get("metadatos", {}),
+            )
+            for entrada in payload.get("historial", [])
+        ],
+        estado_actual=payload["estado_actual"],
+        datos_clave_mencionados=payload.get("datos_clave_mencionados", {}),
+        emociones_cliente=payload.get("emociones_cliente", []),
+    )
+    return contexto

--- a/src/autobot/demo.py
+++ b/src/autobot/demo.py
@@ -1,0 +1,99 @@
+"""Utilidades para ejecutar una simulación de ejemplo del sistema Autobot."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Iterable
+
+from .commands import construir_sistema_comandos
+from .context import AlmacenamientoEnMemoria, GestorContexto
+from .evaluation import LLMClient
+from .models import MensajeConversacion
+
+
+class LLMDePrueba(LLMClient):
+    """Cliente de LLM determinista pensado para pruebas manuales."""
+
+    async def generate(  # type: ignore[override]
+        self, prompt: str, *, temperature: float, max_tokens: int
+    ) -> str:
+        """Genera una respuesta predecible compatible con el motor de evaluación."""
+
+        _ = (prompt, temperature, max_tokens)
+        return (
+            "PUNTAJE: 4\n"
+            "JUSTIFICACION: Evaluación simulada para el criterio analizado.\n"
+            "EVIDENCIAS:\n"
+            '- Turno 2: "El agente ofreció una solución concreta." (impacto=positivo)\n'
+            '- Turno 4: "Se resumieron los próximos pasos." (impacto=positivo)'
+        )
+
+
+async def _generar_historial_demo(gestor: GestorContexto, sesion_id: str) -> None:
+    """Carga un intercambio básico entre cliente y agente para la demo."""
+
+    mensajes: Iterable[MensajeConversacion] = (
+        MensajeConversacion(
+            turno=1,
+            rol="cliente",
+            contenido=(
+                "Hola, hice un pedido de acero y aún no tengo confirmación de entrega. "
+                "¿Pueden ayudarme?"
+            ),
+            timestamp=datetime.now(UTC),
+        ),
+        MensajeConversacion(
+            turno=2,
+            rol="agente",
+            contenido=(
+                "Hola, lamento la demora. Verifiqué el pedido y el camión sale hoy a las "
+                "16:00 con seguimiento en tiempo real."
+            ),
+            timestamp=datetime.now(UTC),
+        ),
+        MensajeConversacion(
+            turno=3,
+            rol="cliente",
+            contenido="Perfecto, gracias por la confirmación y el horario exacto.",
+            timestamp=datetime.now(UTC),
+        ),
+        MensajeConversacion(
+            turno=4,
+            rol="agente",
+            contenido=(
+                "Queda agendado el envío y te contactaré cuando llegue al obrador. "
+                "¿Necesitas algo más?"
+            ),
+            timestamp=datetime.now(UTC),
+        ),
+    )
+
+    for mensaje in mensajes:
+        gestor.agregar_mensaje(sesion_id, mensaje)
+
+
+async def _ejecutar_demo_asincrona() -> str:
+    """Orquesta la simulación de ejemplo completa y devuelve el informe final."""
+
+    almacenamiento = AlmacenamientoEnMemoria()
+    gestor = GestorContexto(almacenamiento)
+    llm = LLMDePrueba()
+    sistema = construir_sistema_comandos(gestor, llm)
+
+    sesion_id = "demo-local"
+    inicio = await sistema.procesar("comenzar test", sesion_id)
+    await _generar_historial_demo(gestor, sesion_id)
+    informe = await sistema.procesar("/finalizar", sesion_id)
+
+    return f"{inicio}\n\n{informe}"
+
+
+def ejecutar_demo() -> str:
+    """Ejecuta la demo en un nuevo bucle de eventos y devuelve el resultado."""
+
+    return asyncio.run(_ejecutar_demo_asincrona())
+
+
+if __name__ == "__main__":
+    print(ejecutar_demo())

--- a/src/autobot/evaluation.py
+++ b/src/autobot/evaluation.py
@@ -1,0 +1,300 @@
+"""Motor de evaluación y rúbrica para medir el desempeño del agente."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Dict, Iterable, List, Protocol, Tuple
+
+from .models import (
+    ContextoConversacion,
+    CriterioEvaluacion,
+    EvidenciaEvaluacion,
+    ResultadoEvaluacion,
+)
+
+
+class LLMClient(Protocol):
+    """Interfaz mínima requerida para interactuar con un modelo de lenguaje."""
+
+    async def generate(
+        self, prompt: str, *, temperature: float, max_tokens: int
+    ) -> str:
+        """Genera una respuesta a partir de un prompt."""
+
+
+@dataclass
+class DefinicionCriterio:
+    """Encapsula la configuración de un criterio de evaluación."""
+
+    peso: float
+    descripcion: str
+    escala: Dict[int, str]
+    indicadores_positivos: Iterable[str]
+    indicadores_negativos: Iterable[str]
+
+
+class RubricaEvaluacion:
+    """Define los criterios que se aplican durante la evaluación."""
+
+    def __init__(self) -> None:
+        self.criterios: Dict[str, DefinicionCriterio] = {
+            "empatia_y_tono": DefinicionCriterio(
+                peso=0.18,
+                descripcion="Capacidad de conectar emocionalmente con el cliente",
+                escala={
+                    1: "Sin empatía. Respuestas frías o robotizadas.",
+                    2: "Empatía mínima y poco personalizada.",
+                    3: "Empatía moderada con reconocimiento parcial del impacto.",
+                    4: "Buena empatía con validación emocional clara.",
+                    5: "Empatía excepcional y proactiva.",
+                },
+                indicadores_positivos=[
+                    "Usa el nombre del cliente",
+                    "Reconoce específicamente el problema",
+                    "Valida emociones",
+                    "Pide disculpas genuinas",
+                ],
+                indicadores_negativos=[
+                    "Ignora el tono emocional",
+                    "Usa plantillas genéricas",
+                    "No ofrece disculpas",
+                    "Adopta un tono defensivo",
+                ],
+            ),
+            "claridad_y_comunicacion": DefinicionCriterio(
+                peso=0.15,
+                descripcion="Mensajes comprensibles, bien estructurados y sin ambigüedades",
+                escala={
+                    1: "Mensajes confusos o con contradicciones.",
+                    2: "Información desordenada que requiere aclaraciones.",
+                    3: "Comunicación aceptable con algunas dudas.",
+                    4: "Mensajes claros y completos.",
+                    5: "Comunicación impecable con resúmenes y énfasis correctos.",
+                },
+                indicadores_positivos=[
+                    "Uso de listas",
+                    "Resumen de pasos",
+                    "Lenguaje simple",
+                    "Confirmación de entendimiento",
+                ],
+                indicadores_negativos=[
+                    "Respuestas ambiguas",
+                    "Uso excesivo de jerga",
+                    "Falta de estructura",
+                    "Bloques extensos sin separación",
+                ],
+            ),
+            "resolucion_y_proactividad": DefinicionCriterio(
+                peso=0.20,
+                descripcion="Capacidad de resolver el problema o avanzar hacia la solución",
+                escala={
+                    1: "No ofrece solución y deriva sin ownership.",
+                    2: "Propuestas vagas o insuficientes.",
+                    3: "Solución correcta pero con esfuerzo del cliente.",
+                    4: "Solución concreta y responsable.",
+                    5: "Solución excepcional con alternativas y anticipación.",
+                },
+                indicadores_positivos=[
+                    "Ofrece solución temprana",
+                    "Propone alternativas",
+                    "Asume responsabilidad",
+                    "Ofrece compensación",
+                    "Entrega plazos concretos",
+                ],
+                indicadores_negativos=[
+                    "Deriva sin intento",
+                    "Soluciones vagas",
+                    "Sin compensación",
+                    "Sin comprometer plazos",
+                ],
+            ),
+        }
+
+    def obtener(self, nombre: str) -> DefinicionCriterio:
+        return self.criterios[nombre]
+
+    def nombres(self) -> Iterable[str]:
+        return self.criterios.keys()
+
+
+class AnalizadorConversacion:
+    """Evalúa conversaciones completas para generar informes estructurados."""
+
+    def __init__(
+        self, llm_client: LLMClient, rubrica: RubricaEvaluacion | None = None
+    ) -> None:
+        self._llm = llm_client
+        self._rubrica = rubrica or RubricaEvaluacion()
+
+    async def evaluar_conversacion(
+        self, contexto: ContextoConversacion
+    ) -> ResultadoEvaluacion:
+        criterios_evaluados: List[CriterioEvaluacion] = []
+        for nombre in self._rubrica.nombres():
+            definicion = self._rubrica.obtener(nombre)
+            criterios_evaluados.append(
+                await self._evaluar_criterio(contexto, nombre, definicion)
+            )
+
+        puntaje_global = sum(
+            criterio.puntaje * criterio.peso * 20 for criterio in criterios_evaluados
+        )
+        fortalezas, oportunidades = self._extraer_fortalezas_oportunidades(
+            criterios_evaluados
+        )
+        recomendaciones = self._generar_recomendaciones(oportunidades)
+
+        metricas = {
+            "turnos_totales": len(contexto.historial),
+            "turnos_hasta_empatia": None,
+            "turnos_hasta_solucion": None,
+            "confirmaciones_entendimiento": 0,
+            "interrupciones": 0,
+            "tiempo_respuesta_promedio": 0.0,
+        }
+
+        resumen = self._generar_resumen_ejecutivo(
+            puntaje_global, fortalezas, oportunidades
+        )
+
+        return ResultadoEvaluacion(
+            sesion_id=contexto.sesion_id,
+            timestamp_evaluacion=datetime.now(UTC),
+            personalidad_cliente=contexto.configuracion.personalidad,
+            canal=contexto.configuracion.canal,
+            escenario=contexto.configuracion.escenario,
+            criterios=criterios_evaluados,
+            puntaje_global=puntaje_global,
+            fortalezas=fortalezas,
+            oportunidades_mejora=oportunidades,
+            recomendaciones=recomendaciones,
+            metricas=metricas,
+            resumen_ejecutivo=resumen,
+        )
+
+    async def _evaluar_criterio(
+        self,
+        contexto: ContextoConversacion,
+        nombre: str,
+        definicion: DefinicionCriterio,
+    ) -> CriterioEvaluacion:
+        prompt = self._construir_prompt(contexto, nombre, definicion)
+        respuesta = await self._llm.generate(prompt, temperature=0.3, max_tokens=800)
+        puntaje, justificacion, evidencias = self._parsear_respuesta(respuesta, nombre)
+        return CriterioEvaluacion(
+            nombre=nombre,
+            puntaje=puntaje,
+            peso=definicion.peso,
+            justificacion=justificacion,
+            evidencias=evidencias,
+        )
+
+    @staticmethod
+    def _construir_prompt(
+        contexto: ContextoConversacion,
+        nombre: str,
+        definicion: DefinicionCriterio,
+    ) -> str:
+        historial = "\n".join(
+            f"Turno {mensaje.turno} ({mensaje.rol}): {mensaje.contenido}"
+            for mensaje in contexto.historial
+        )
+        escala = "\n".join(
+            f"{nivel}: {detalle}" for nivel, detalle in definicion.escala.items()
+        )
+        indicadores_positivos = "\n".join(
+            f"- {texto}" for texto in definicion.indicadores_positivos
+        )
+        indicadores_negativos = "\n".join(
+            f"- {texto}" for texto in definicion.indicadores_negativos
+        )
+        return (
+            f"Evalúa el criterio {nombre} para la siguiente conversación.\n\n"
+            f"Descripción: {definicion.descripcion}\n"
+            f"Escala:\n{escala}\n\n"
+            f"Indicadores positivos:\n{indicadores_positivos}\n\n"
+            f"Indicadores negativos:\n{indicadores_negativos}\n\n"
+            f"Conversación completa:\n{historial}\n\n"
+            "Responde en formato estructurado:\n"
+            "PUNTAJE: <número>\n"
+            "JUSTIFICACION: <texto>\n"
+            "EVIDENCIAS:\n"
+            '- Turno <número>: "cita literal" (impacto=<positivo|negativo|neutral>)'
+        )
+
+    @staticmethod
+    def _parsear_respuesta(
+        respuesta: str, criterio: str
+    ) -> Tuple[int, str, List[EvidenciaEvaluacion]]:
+        puntaje_match = re.search(r"PUNTAJE:\s*(\d)", respuesta)
+        if puntaje_match is None:
+            raise ValueError(
+                f"No se encontró puntaje en la respuesta del criterio {criterio}"
+            )
+        puntaje = int(puntaje_match.group(1))
+
+        justificacion_match = re.search(
+            r"JUSTIFICACION:\s*(.+?)(?:\nEVIDENCIAS:|$)", respuesta, re.S
+        )
+        if justificacion_match is None:
+            raise ValueError(
+                f"No se encontró justificación en la respuesta del criterio {criterio}"
+            )
+        justificacion = justificacion_match.group(1).strip()
+
+        evidencias: List[EvidenciaEvaluacion] = []
+        for coincidencia in re.finditer(
+            r"- Turno (\d+): \"(.+?)\" \(impacto=(positivo|negativo|neutral)\)",
+            respuesta,
+        ):
+            evidencias.append(
+                EvidenciaEvaluacion(
+                    criterio=criterio,
+                    turno=int(coincidencia.group(1)),
+                    extracto=coincidencia.group(2),
+                    impacto=coincidencia.group(3),
+                )
+            )
+
+        return puntaje, justificacion, evidencias
+
+    @staticmethod
+    def _extraer_fortalezas_oportunidades(
+        criterios: Iterable[CriterioEvaluacion],
+    ) -> Tuple[List[str], List[str]]:
+        fortalezas = [
+            f"{criterio.nombre} destacado con puntaje {criterio.puntaje}/5"
+            for criterio in criterios
+            if criterio.puntaje >= 4
+        ]
+        oportunidades = [
+            f"Mejorar {criterio.nombre} (puntaje {criterio.puntaje}/5)"
+            for criterio in criterios
+            if criterio.puntaje <= 3
+        ]
+        return fortalezas, oportunidades
+
+    @staticmethod
+    def _generar_recomendaciones(oportunidades: Iterable[str]) -> List[str]:
+        return [f"Desarrollar plan específico para: {texto}" for texto in oportunidades]
+
+    @staticmethod
+    def _generar_resumen_ejecutivo(
+        puntaje_global: float, fortalezas: List[str], oportunidades: List[str]
+    ) -> str:
+        encabezado = (
+            "Desempeño general bueno" if puntaje_global >= 70 else "Desempeño a mejorar"
+        )
+        fortalezas_texto = (
+            ", ".join(fortalezas) if fortalezas else "sin fortalezas destacadas"
+        )
+        oportunidades_texto = (
+            ", ".join(oportunidades) if oportunidades else "sin oportunidades críticas"
+        )
+        return (
+            f"{encabezado}. Puntaje global {puntaje_global:.1f}/100."
+            f" Fortalezas: {fortalezas_texto}."
+            f" Oportunidades: {oportunidades_texto}."
+        )

--- a/src/autobot/models.py
+++ b/src/autobot/models.py
@@ -1,0 +1,117 @@
+"""Modelos de datos centrales para el sistema de simulación."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Literal, Optional
+
+
+class PersonalidadCliente(str, Enum):
+    """Enumeración de personalidades disponibles para los clientes simulados."""
+
+    ENOJADO_IMPACIENTE = "enojado_impaciente"
+    ANSIOSO_DETALLISTA = "ansioso_detallista"
+    SARCASTICO_EXIGENTE = "sarcastico_exigente"
+    CONFUNDIDO_AMABLE = "confundido_amable"
+    PROFESIONAL_DIRECTO = "profesional_directo"
+    AGRESIVO_DEMANDANTE = "agresivo_demandante"
+    RESIGNADO_CANSADO = "resignado_cansado"
+
+
+class CanalComunicacion(str, Enum):
+    """Canales de comunicación soportados por la simulación."""
+
+    WHATSAPP = "whatsapp"
+    EMAIL = "email"
+    CHAT = "chat"
+    TELEFONO = "telefono"
+
+
+@dataclass
+class EscenarioObra:
+    """Representa un escenario realista dentro de la industria de construcción."""
+
+    id: str
+    titulo: str
+    descripcion: str
+    complejidad: Literal["baja", "media", "alta"]
+    area: str
+    palabras_clave: List[str]
+    solucion_esperada: str
+    tiempo_estimado_resolucion: int
+
+
+@dataclass
+class ConfiguracionSimulacion:
+    """Parámetros iniciales que definen una simulación."""
+
+    personalidad: PersonalidadCliente
+    canal: CanalComunicacion
+    escenario: EscenarioObra
+    timestamp_inicio: datetime
+    duracion_maxima: int = 20
+    nivel_dificultad: float = 0.7
+
+
+@dataclass
+class MensajeConversacion:
+    """Unidad básica del diálogo entre cliente y agente."""
+
+    turno: int
+    rol: Literal["cliente", "agente"]
+    contenido: str
+    timestamp: datetime
+    metadatos: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ContextoConversacion:
+    """Estado completo de la conversación en curso."""
+
+    sesion_id: str
+    configuracion: ConfiguracionSimulacion
+    estado_actual: Literal["iniciando", "en_progreso", "resolviendo", "finalizado"]
+    historial: List[MensajeConversacion] = field(default_factory=list)
+    datos_clave_mencionados: Dict[str, bool] = field(default_factory=dict)
+    emociones_cliente: List[str] = field(default_factory=list)
+
+
+@dataclass
+class EvidenciaEvaluacion:
+    """Fragmento textual que respalda un puntaje obtenido."""
+
+    criterio: str
+    turno: int
+    extracto: str
+    impacto: Literal["positivo", "negativo", "neutral"]
+
+
+@dataclass
+class CriterioEvaluacion:
+    """Resultado asociado a un criterio individual de la rúbrica."""
+
+    nombre: str
+    puntaje: int
+    peso: float
+    justificacion: str
+    evidencias: List[EvidenciaEvaluacion]
+
+
+@dataclass
+class ResultadoEvaluacion:
+    """Informe integral que resume la evaluación del desempeño."""
+
+    sesion_id: str
+    timestamp_evaluacion: datetime
+    personalidad_cliente: PersonalidadCliente
+    canal: CanalComunicacion
+    escenario: EscenarioObra
+    criterios: List[CriterioEvaluacion]
+    puntaje_global: float
+    fortalezas: List[str]
+    oportunidades_mejora: List[str]
+    recomendaciones: List[str]
+    metricas: Dict[str, Optional[float]]
+    resumen_ejecutivo: str

--- a/src/autobot/personalities.py
+++ b/src/autobot/personalities.py
@@ -1,0 +1,136 @@
+"""Definición de perfiles de personalidad para clientes simulados."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+from .models import PersonalidadCliente
+
+
+@dataclass
+class PerfilPersonalidad:
+    """Perfil psicológico completo que guía el comportamiento del cliente."""
+
+    tipo: PersonalidadCliente
+    tono_predominante: str
+    vocabulario: List[str]
+    emojis_permitidos: List[str]
+    longitud_mensaje_promedio: Tuple[int, int]
+    paciencia_inicial: float
+    velocidad_escalamiento: float
+    probabilidad_interrupcion: float
+    palabras_calmantes: List[str]
+    palabras_irritantes: List[str]
+    respuesta_a_empatia: str
+    respuesta_a_solucion_rapida: str
+    respuesta_a_derivacion: str
+    respuesta_a_demora: str
+    satisfaccion_minima_aceptable: float
+    informacion_critica_requerida: List[str]
+
+
+PERFILES_PERSONALIDAD: Dict[PersonalidadCliente, PerfilPersonalidad] = {
+    PersonalidadCliente.ENOJADO_IMPACIENTE: PerfilPersonalidad(
+        tipo=PersonalidadCliente.ENOJADO_IMPACIENTE,
+        tono_predominante="agresivo y demandante, con uso ocasional de mayúsculas",
+        vocabulario=[
+            "URGENTE",
+            "inaceptable",
+            "ya es la tercera vez",
+            "quiero hablar con un supervisor",
+            "esto es el colmo",
+        ],
+        emojis_permitidos=["😡", "🤬", "😤", "⏰"],
+        longitud_mensaje_promedio=(15, 40),
+        paciencia_inicial=0.2,
+        velocidad_escalamiento=0.8,
+        probabilidad_interrupcion=0.3,
+        palabras_calmantes=[
+            "entiendo su frustración",
+            "me haré cargo personalmente",
+            "compensación",
+        ],
+        palabras_irritantes=[
+            "política de la empresa",
+            "no está en mis manos",
+            "tendrá que esperar",
+        ],
+        respuesta_a_empatia="Eso está bien, pero necesito una solución ahora mismo.",
+        respuesta_a_solucion_rapida="Esto debió resolverse antes, no quiero más demoras.",
+        respuesta_a_derivacion="No me deriven más, ya hablé con varias personas.",
+        respuesta_a_demora="¿Otra vez esperar? Esto es inaceptable.",
+        satisfaccion_minima_aceptable=0.6,
+        informacion_critica_requerida=[
+            "fecha_compromiso",
+            "responsable",
+            "compensacion",
+        ],
+    ),
+    PersonalidadCliente.CONFUNDIDO_AMABLE: PerfilPersonalidad(
+        tipo=PersonalidadCliente.CONFUNDIDO_AMABLE,
+        tono_predominante="cordial pero inseguro, pide aclaraciones con frecuencia",
+        vocabulario=[
+            "disculpá",
+            "no termino de entender",
+            "¿podrías explicarme?",
+            "me preocupa",
+        ],
+        emojis_permitidos=["🙂", "🤔"],
+        longitud_mensaje_promedio=(20, 45),
+        paciencia_inicial=0.7,
+        velocidad_escalamiento=0.3,
+        probabilidad_interrupcion=0.1,
+        palabras_calmantes=[
+            "te explico paso a paso",
+            "no te preocupes",
+            "estoy para ayudarte",
+        ],
+        palabras_irritantes=[
+            "ya lo expliqué",
+            "es obvio",
+            "fijate en el manual",
+        ],
+        respuesta_a_empatia="Gracias, valoro que te tomes el tiempo.",
+        respuesta_a_solucion_rapida="¡Qué bueno! Avisame cómo seguimos.",
+        respuesta_a_derivacion="¿Creés que la otra persona tendrá toda la info?",
+        respuesta_a_demora="¿Podemos verlo hoy? Me ayudaría mucho.",
+        satisfaccion_minima_aceptable=0.7,
+        informacion_critica_requerida=["estado_pedido", "plazo_resolucion"],
+    ),
+    PersonalidadCliente.PROFESIONAL_DIRECTO: PerfilPersonalidad(
+        tipo=PersonalidadCliente.PROFESIONAL_DIRECTO,
+        tono_predominante="formal y concreto, enfocado en resultados",
+        vocabulario=[
+            "necesito confirmación",
+            "plazo comprometido",
+            "responsable designado",
+            "seguimiento",
+        ],
+        emojis_permitidos=[],
+        longitud_mensaje_promedio=(10, 25),
+        paciencia_inicial=0.5,
+        velocidad_escalamiento=0.4,
+        probabilidad_interrupcion=0.05,
+        palabras_calmantes=[
+            "documentación respaldatoria",
+            "informes actualizados",
+            "plan de acción",
+        ],
+        palabras_irritantes=[
+            "quizás",
+            "veremos",
+            "no puedo asegurar",
+        ],
+        respuesta_a_empatia="Agradezco la comprensión, ahora necesito un plan claro.",
+        respuesta_a_solucion_rapida="Perfecto, enviame el cronograma actualizado.",
+        respuesta_a_derivacion="Acepto la derivación si queda claro quién se responsabiliza.",
+        respuesta_a_demora="Requiero nueva fecha comprometida por escrito.",
+        satisfaccion_minima_aceptable=0.75,
+        informacion_critica_requerida=[
+            "plan_accion",
+            "responsable",
+            "fecha_compromiso",
+        ],
+    ),
+}

--- a/src/autobot/scenarios.py
+++ b/src/autobot/scenarios.py
@@ -1,0 +1,125 @@
+"""Colección de escenarios realistas utilizados en las simulaciones."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .models import EscenarioObra
+
+
+ESCENARIOS_OBRA: List[EscenarioObra] = [
+    EscenarioObra(
+        id="ESC-001",
+        titulo="Retraso en entrega de materiales críticos",
+        descripcion=(
+            "El cliente es supervisor de obra en un proyecto petrolero. Hace 5 días "
+            "ordenó 200 bolsas de cemento especial para fundaciones críticas."
+            " La entrega prometida en 72 horas no se cumplió, la obra está paralizada"
+            " y hay operarios inactivos mientras la gerencia presiona por avances."
+            " Código de pedido: #CM-2024-8847."
+        ),
+        complejidad="alta",
+        area="logistica",
+        palabras_clave=[
+            "cemento",
+            "obra paralizada",
+            "entrega",
+            "72 horas",
+            "Vaca Muerta",
+        ],
+        solucion_esperada=(
+            "1. Pedir disculpas genuinas\n"
+            "2. Verificar estado del pedido con el código\n"
+            "3. Ofrecer envío express sin costo adicional\n"
+            "4. Proveer tracking en tiempo real\n"
+            "5. Compensación: descuento o materiales extra\n"
+            "6. Asignar responsable con contacto directo\n"
+            "7. Comprometer fecha y hora de entrega en 24 horas"
+        ),
+        tiempo_estimado_resolucion=8,
+    ),
+    EscenarioObra(
+        id="ESC-002",
+        titulo="Material defectuoso instalado - riesgo de obra",
+        descripcion=(
+            "Un contratista recibió perfiles de acero instalados en un 40 %. Un"
+            " inspector detectó espesor menor al especificado, con riesgo"
+            " estructural y potenciales acciones legales. Lote: ACERO-L0445."
+        ),
+        complejidad="alta",
+        area="calidad",
+        palabras_clave=[
+            "acero",
+            "defectuoso",
+            "inspección",
+            "norma IRAM",
+            "acciones legales",
+        ],
+        solucion_esperada=(
+            "1. Reconocer la gravedad del problema\n"
+            "2. Enviar ingeniero auditor en 24 horas\n"
+            "3. Retirar material defectuoso sin costo\n"
+            "4. Reemplazar por material certificado\n"
+            "5. Cubrir desmontaje y reinstalación\n"
+            "6. Emitir carta de garantía técnica\n"
+            "7. Auditar lotes del mismo proveedor\n"
+            "8. Ofrecer compensación económica"
+        ),
+        tiempo_estimado_resolucion=12,
+    ),
+    EscenarioObra(
+        id="ESC-003",
+        titulo="Error en facturación - cobro duplicado",
+        descripcion=(
+            "Una constructora detectó el cobro duplicado de un pedido de"
+            " cerámicos por $850.000 ARS. Pagaron ambas facturas por error"
+            " administrativo y necesitan reintegro urgente para afrontar"
+            " pagos de nómina."
+        ),
+        complejidad="media",
+        area="administracion",
+        palabras_clave=[
+            "facturación",
+            "duplicado",
+            "reintegro",
+            "transferencia",
+        ],
+        solucion_esperada=(
+            "1. Validar facturas reportadas\n"
+            "2. Confirmar error y disculparse\n"
+            "3. Iniciar devolución inmediata por transferencia\n"
+            "4. Plazo máximo de 48 horas hábiles\n"
+            "5. Enviar comprobante de transferencia\n"
+            "6. Compartir contacto de administración\n"
+            "7. Ofrecer bono o descuento compensatorio"
+        ),
+        tiempo_estimado_resolucion=6,
+    ),
+    EscenarioObra(
+        id="ESC-004",
+        titulo="Cambio de especificaciones técnicas post-pedido",
+        descripcion=(
+            "El cliente solicitó aberturas de aluminio y el arquitecto cambió"
+            " el proyecto a vidrios DVH cuando la producción ya había"
+            " comenzado. Requiere conocer opciones, demoras y costos"
+            " asociados para el pedido #AB-2024-1102."
+        ),
+        complejidad="baja",
+        area="ventas",
+        palabras_clave=[
+            "aberturas",
+            "modificación",
+            "DVH",
+            "producción",
+        ],
+        solucion_esperada=(
+            "1. Mostrar empatía por cambios de proyecto\n"
+            "2. Verificar estado de fabricación\n"
+            "3. Explicar opciones según avance\n"
+            "4. Enviar cotización en menos de 4 horas\n"
+            "5. Facilitar proceso sin trabas\n"
+            "6. Confirmar nueva fecha de entrega"
+        ),
+        tiempo_estimado_resolucion=5,
+    ),
+]

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,34 @@
+"""Pruebas para la ejecución de la demo integrada."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from autobot.demo import ejecutar_demo
+
+
+def test_ejecutar_demo_devuelve_informe() -> None:
+    """La demo debe generar un informe con puntaje global."""
+
+    resultado = ejecutar_demo()
+    assert "Puntaje global" in resultado
+    assert "Evaluación de la sesión" in resultado
+
+
+def test_paquete_exponible_como_modulo() -> None:
+    """Permite ejecutar la demo con `python -m autobot`."""
+
+    entorno = os.environ.copy()
+    pythonpath = entorno.get("PYTHONPATH", "")
+    ruta_src = str(Path("src").resolve())
+    entorno["PYTHONPATH"] = (f"{ruta_src}{os.pathsep}{pythonpath}" if pythonpath else ruta_src)
+
+    proceso = subprocess.run(
+        [sys.executable, "-m", "autobot"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=entorno,
+    )
+    assert "Puntaje global" in proceso.stdout

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,93 @@
+"""Pruebas básicas para los modelos del sistema."""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from autobot.context import AlmacenamientoEnMemoria, GestorContexto
+from autobot.evaluation import AnalizadorConversacion, RubricaEvaluacion
+from autobot.models import (
+    CanalComunicacion,
+    ConfiguracionSimulacion,
+    ContextoConversacion,
+    MensajeConversacion,
+    PersonalidadCliente,
+)
+from autobot.scenarios import ESCENARIOS_OBRA
+
+
+class DummyLLM:
+    """Cliente LLM que devuelve respuestas deterministas para pruebas."""
+
+    async def generate(
+        self, prompt: str, *, temperature: float, max_tokens: int
+    ) -> str:  # noqa: D401
+        del prompt, temperature, max_tokens
+        return (
+            "PUNTAJE: 4\n"
+            "JUSTIFICACION: Respuesta de ejemplo consistente.\n"
+            "EVIDENCIAS:\n"
+            '- Turno 1: "Mensaje" (impacto=positivo)'
+        )
+
+
+@pytest.fixture()
+def contexto() -> ContextoConversacion:
+    configuracion = ConfiguracionSimulacion(
+        personalidad=PersonalidadCliente.ENOJADO_IMPACIENTE,
+        canal=CanalComunicacion.CHAT,
+        escenario=ESCENARIOS_OBRA[0],
+        timestamp_inicio=datetime.now(UTC),
+    )
+    return ContextoConversacion(
+        sesion_id="test",
+        configuracion=configuracion,
+        historial=[
+            MensajeConversacion(
+                turno=1,
+                rol="cliente",
+                contenido="Necesito ayuda urgente",
+                timestamp=datetime.now(UTC),
+            ),
+            MensajeConversacion(
+                turno=2,
+                rol="agente",
+                contenido="Te ayudo a continuación",
+                timestamp=datetime.now(UTC),
+            ),
+        ],
+        estado_actual="en_progreso",
+    )
+
+
+def test_escenarios_disponibles() -> None:
+    assert len(ESCENARIOS_OBRA) >= 4
+
+
+def test_evaluacion_generica(contexto: ContextoConversacion) -> None:
+    analizador = AnalizadorConversacion(DummyLLM(), RubricaEvaluacion())
+    resultado = asyncio_run(analizador.evaluar_conversacion(contexto))
+    assert resultado.puntaje_global > 0
+
+
+def asyncio_run(coro):
+    """Ejecuta una corrutina dentro del loop de pruebas."""
+
+    return asyncio.run(coro)
+
+
+def test_gestor_contexto(contexto: ContextoConversacion) -> None:
+    almacenamiento = AlmacenamientoEnMemoria()
+    gestor = GestorContexto(almacenamiento)
+    gestor.inicializar_contexto(contexto)
+    mensaje = MensajeConversacion(
+        turno=3,
+        rol="cliente",
+        contenido="Pedido #12345 hace 5 días",
+        timestamp=datetime.now(UTC),
+    )
+    gestor.agregar_mensaje(contexto.sesion_id, mensaje)
+    contexto_recuperado = gestor.obtener_contexto(contexto.sesion_id)
+    assert contexto_recuperado.datos_clave_mencionados["numero_pedido"]
+    assert contexto_recuperado.datos_clave_mencionados["fecha_problema"]


### PR DESCRIPTION
## Summary
- documentar los pasos de instalación con activación para Windows y agregar `python -m autobot` como alternativa de ejecución
- exponer el módulo `demo` en el paquete y añadir un `__main__` para ejecutar la simulación con `python -m autobot`
- cubrir la nueva vía de ejecución con una prueba que ajusta el `PYTHONPATH` al invocar el módulo

## Testing
- pytest
- ruff check src tests

------
https://chatgpt.com/codex/tasks/task_e_68e00a43274c832393830aad23b043c2